### PR TITLE
Add basic Jest tests and CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+
+let app;
+
+beforeAll(() => {
+  process.env.ADMIN_PASSWORD = bcrypt.hashSync('secret', 10);
+  process.env.JWT_SECRET = 'testsecret';
+  app = require('../server');
+});
+
+describe('Authentication', () => {
+  test('successful login returns 204 and sets cookie', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ password: 'secret' });
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['set-cookie']).toBeDefined();
+  });
+
+  test('wrong password returns 401', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ password: 'wrong' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('Protected route', () => {
+  test('unauthorized access to /api/knowledge', async () => {
+    const res = await request(app).get('/api/knowledge');
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js"
   },
   "engines": {
@@ -23,5 +23,9 @@
     "jsonwebtoken": "^9.0.0",
     "node-schedule": "^2.1.1",
     "pg": "^8.16.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -591,6 +591,10 @@ app.delete('/api/knowledge/:id', async (req, res) => {
     }
 });
 
-app.listen(port, () => {
-  console.log(`Server avviato su http://localhost:${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server avviato su http://localhost:${port}`);
+  });
+} else {
+  module.exports = app;
+}


### PR DESCRIPTION
## Summary
- export express app for testing
- set up Jest and Supertest
- add authentication and protected route tests
- define `npm test` script
- create GitHub Actions workflow to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b866d5f08331a9c86c10a4566807