### PR TITLE
Add database schema and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # Crm_Modul_Group
-# Crm_Modul_Group
+
+This project runs an Express server using a PostgreSQL database.  
+Below are the basic steps required to create the database schema and start the server.
+
+## Database setup
+
+1. Install PostgreSQL and create a database (for example `crm`).
+
+   ```bash
+   createdb crm
+   ```
+
+2. Apply the database schema contained in `schema.sql`:
+
+   ```bash
+   psql -d crm -f schema.sql
+   ```
+
+   The schema creates the `clients` and `knowledge` tables used by the application.
+
+3. Configure your database credentials using `DATABASE_URL` or the standard `PG*` environment variables.
+
+## Running migrations
+
+Whenever the schema changes, re-run the script:
+
+```bash
+psql -d crm -f schema.sql
+```
+
+## Starting the server
+
+Install dependencies and start the application:
+
+```bash
+npm install
+npm start
+```

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,26 @@
+-- Schema for CRM project
+
+-- Clients table
+CREATE TABLE IF NOT EXISTS clients (
+    id SERIAL PRIMARY KEY,
+    id_voiceflow TEXT UNIQUE NOT NULL,
+    nome TEXT,
+    numero TEXT,
+    summary TEXT,
+    conversazioni JSONB DEFAULT '[]'::jsonb,
+    data_modifica TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Knowledge base table
+CREATE TABLE IF NOT EXISTS knowledge (
+    id SERIAL PRIMARY KEY,
+    tipo TEXT NOT NULL,
+    nome TEXT NOT NULL,
+    prezzo TEXT,
+    consegna TEXT,
+    descrizione TEXT,
+    domande JSONB DEFAULT '[]'::jsonb,
+    categorie JSONB DEFAULT '[]'::jsonb,
+    finiture JSONB DEFAULT '[]'::jsonb,
+    domande_finali JSONB DEFAULT '[]'::jsonb
+);


### PR DESCRIPTION
## Summary
- add `schema.sql` describing `clients` and `knowledge` tables
- document DB setup and migrations in README

## Testing
- `npm install` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b864f7548331b7dfb05e5bc3b931