### PR TITLE
Configure CORS via env and secure cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# Crm_Modul_Group
-# Crm_Modul_Group
+# CRM Module
+
+This project exposes a simple CRM backend built with Express.
+
+## Environment variables
+
+- `CORS_ORIGINS` - comma separated list of allowed origins for CORS. If not set, `*` is used.
+- `NODE_ENV` - when set to `production`, cookies are marked as secure.
+
+Run the application with `npm start` after creating a `.env` file with the needed settings.

--- a/server.js
+++ b/server.js
@@ -24,8 +24,10 @@ app.use((err, req, res, next) => {
 app.use(cookieParser());
 
 // Configurazione CORS
+const allowedOriginsEnv = process.env.CORS_ORIGINS;
+const allowedOrigins = allowedOriginsEnv ? allowedOriginsEnv.split(',').map(o => o.trim()) : '*';
 app.use(cors({
-    origin: '*',
+    origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key', 'X-API-KEY'],
     exposedHeaders: ['*', 'Authorization']
@@ -39,16 +41,20 @@ app.post('/api/login', async (req, res) => {
     const token = jwt.sign({ role: 'admin' }, process.env.JWT_SECRET, { expiresIn: '30d' });
   res.cookie('crmToken', token, {
     httpOnly: true,
-        secure: false,
-        sameSite: 'Lax',
-        path: '/',
-        maxAge: 30 * 24 * 60 * 60 * 1000
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'Lax',
+    path: '/',
+    maxAge: 30 * 24 * 60 * 60 * 1000
   }).sendStatus(204);
 });
 
 // Logout route
 app.post('/api/logout', (req, res) => {
-    res.clearCookie('crmToken').sendStatus(204);
+    res.clearCookie('crmToken', {
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'Lax'
+    }).sendStatus(204);
 });
 
 /* ---------- MIDDLEWARE ---------- */


### PR DESCRIPTION
## Summary
- secure cookies in production
- allow CORS origins via `CORS_ORIGINS` env variable
- document env vars in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8637e948331aab95745a63e5cab